### PR TITLE
jscs command fix : need one more dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A successful install will display a tree of installed packages.
 repository
 1. The repository has a script defined that will test all JavaScript in the examples 
 directory. To run it, execute the command `npm test`.
-1. Many errors can be fixed automatically with the command `npm run jscs-fix`.
+1. Many errors can be fixed automatically with the command `npm run jscs --fix`.
 1. After running fix, test again to see what you need to fix manually.
   
 When JSCS encounters errors, it will report them in the console. 


### PR DESCRIPTION
"Many errors can be fixed automatically with the command npm run jscs-fix."
This should be "npm run jscs --fix"

See the documentation. http://jscs.info/overview

--fix (-x)

Will apply fixes to all supported style rules.

jscs path[ path[...]] --fix
